### PR TITLE
Change item sort to be with fluid pipes

### DIFF
--- a/prototypes/fluid-indicator.lua
+++ b/prototypes/fluid-indicator.lua
@@ -264,7 +264,7 @@ data:extend({
     icon = "__Fluid-level-indicator__/graphics/icons/T-icon64.png",
     icon_size = 64,
     flags = {},
-    subgroup = "energy-pipe-distribution",
+    subgroup = data.raw["item"]["pipe"].subgroup,
     order = "f[fluid-level-indicator]",
     place_result = "fluid-level-indicator",
     stack_size = 50
@@ -275,7 +275,7 @@ data:extend({
   icon = "__Fluid-level-indicator__/graphics/icons/straight-icon128.png",
   icon_size = 128,
   flags = {},
-  subgroup = "energy-pipe-distribution",
+  subgroup = data.raw["item"]["pipe"].subgroup,
   order = "f[fluid-level-indicator-straight]",
   place_result = "fluid-level-indicator-straight",
   stack_size = 50


### PR DESCRIPTION
The indicator pipes recipes and items are grouped with electrical poles. This changes the group them with the fluid pipes.